### PR TITLE
Testing s3 coverage comparison

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9898,9 +9898,13 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
-        const funcPercentageDiff = this.getPercentageDiff(total.functions);
+        const comparison = {
+            oldPct: total.functions.oldCovered,
+            newPct: total.functions.newCovered
+        };
+        const funcPercentageDiff = this.getPercentageDiff(comparison);
         return (total &&
-            total.functions.oldPct !== total.functions.newPct &&
+            total.functions.oldCovered !== total.functions.newCovered &&
             funcPercentageDiff < 0 &&
             Math.abs(funcPercentageDiff) >= delta);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9898,13 +9898,9 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
-        const comparison = {
-            oldPct: total.functions.oldCovered,
-            newPct: total.functions.newCovered
-        };
-        const funcPercentageDiff = this.getPercentageDiff(comparison);
+        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
-            total.functions.oldCovered !== total.functions.newCovered &&
+            total.functions.oldPct !== total.functions.newPct &&
             funcPercentageDiff < 0 &&
             Math.abs(funcPercentageDiff) >= delta);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9847,12 +9847,12 @@ class DiffChecker {
             metric.pct = (metric.covered / metric.total) * 100;
         }
         coverageReportNew.total = total;
-        console.log('New Report keys: ', coverageReportNew);
-        console.log('Old Report keys: ', coverageReportOld['/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts']);
-        console.log('Old Report keys: ', coverageReportOld['total']);
-        console.log('Report keys: ', reportKeys);
+        console.log('Old Report Total: ', coverageReportOld['total']);
+        console.log('New Report Total: ', coverageReportNew['total']);
         for (const filePath of reportKeys) {
             if (reportNewKeys.includes(filePath)) {
+                console.log('Old Report keys: ', coverageReportOld[filePath]);
+                console.log('---- DIFF : ------', this.diffCoverageReport[filePath]);
                 this.diffCoverageReport[filePath] = {
                     branches: {
                         newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
@@ -9871,9 +9871,6 @@ class DiffChecker {
                         oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
                     }
                 };
-                if (filePath ===
-                    '/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts')
-                    console.log('----HEYHEY ------', this.diffCoverageReport[filePath]);
             }
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9814,7 +9814,7 @@ const newCoverageIcon = ':sparkles: :new:';
 const removedCoverageIcon = ':x:';
 class DiffChecker {
     constructor(coverageReportNew, coverageReportOld) {
-        var _a, _b, _c, _d, _e, _f, _g, _h;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
         this.diffCoverageReport = {};
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
@@ -9849,7 +9849,7 @@ class DiffChecker {
         coverageReportNew.total = total;
         for (const filePath of reportKeys) {
             if (reportNewKeys.includes(filePath)) {
-                console.log(`__________ ${filePath} _________`);
+                console.log(`_________ ${filePath} _________`);
                 console.log(`>> Old Report: <<'`, coverageReportOld[filePath]);
                 console.log(`>>> New Report: <<<'`, coverageReportNew[filePath]);
                 this.diffCoverageReport[filePath] = {
@@ -9867,7 +9867,9 @@ class DiffChecker {
                     },
                     functions: {
                         newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
-                        oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
+                        oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions),
+                        newCovered: (_j = coverageReportNew[filePath]) === null || _j === void 0 ? void 0 : _j.functions.covered,
+                        oldCovered: (_k = coverageReportOld[filePath]) === null || _k === void 0 ? void 0 : _k.functions.covered
                     }
                 };
                 console.log(`-- DIF: --`, this.diffCoverageReport[filePath]);
@@ -9891,9 +9893,13 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
-        const funcPercentageDiff = this.getPercentageDiff(total.functions);
+        const comparison = {
+            oldPct: total.functions.oldCovered,
+            newPct: total.functions.newCovered
+        };
+        const funcPercentageDiff = this.getPercentageDiff(comparison);
         return (total &&
-            total.functions.oldPct !== total.functions.newPct &&
+            total.functions.oldCovered !== total.functions.newCovered &&
             funcPercentageDiff < 0 &&
             Math.abs(funcPercentageDiff) >= delta);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9844,7 +9844,7 @@ class DiffChecker {
         }
         for (const metricType in total) {
             const metric = total[metricType];
-            metric.pct = (metric.covered / metric.total) * 100;
+            metric.pct = ((metric.covered / metric.total) * 100).toFixed(2);
         }
         coverageReportNew.total = total;
         for (const filePath of reportKeys) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9837,18 +9837,19 @@ class DiffChecker {
             const item = temporaryReport[key];
             for (const metricType in item) {
                 const metric = item[metricType];
-                total[metricType]['total'] += metric.total;
-                total[metricType]['covered'] += metric.covered;
-                total[metricType]['skipped'] += metric.skipped;
+                total[metricType]['total'] += Number(metric.total);
+                total[metricType]['covered'] += Number(metric.covered);
+                total[metricType]['skipped'] += Number(metric.skipped);
             }
         }
         for (const metricType in total) {
             const metric = total[metricType];
-            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
+            metric.pct = (metric.covered / metric.total) * 100;
         }
         coverageReportNew.total = total;
         console.log('New Report keys: ', coverageReportNew);
-        console.log('Old Report keys: ', coverageReportOld);
+        console.log('Old Report keys: ', coverageReportOld['/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts']);
+        console.log('Old Report keys: ', coverageReportOld['total']);
         console.log('Report keys: ', reportKeys);
         for (const filePath of reportKeys) {
             if (reportNewKeys.includes(filePath)) {
@@ -9870,6 +9871,9 @@ class DiffChecker {
                         oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
                     }
                 };
+                if (filePath ===
+                    '/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts')
+                    console.log('----HEYHEY ------', this.diffCoverageReport[filePath]);
             }
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9844,7 +9844,7 @@ class DiffChecker {
         }
         for (const metricType in total) {
             const metric = total[metricType];
-            metric.pct = ((metric.covered / metric.total) * 100).toFixed(2);
+            metric.pct = +(metric.covered / metric.total).toFixed(2) * 100;
         }
         coverageReportNew.total = total;
         for (const filePath of reportKeys) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9860,14 +9860,16 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
+        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            -this.getPercentageDiff(total.functions) >= delta);
+            funcPercentageDiff < 0 &&
+            Math.abs(funcPercentageDiff) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
-        const keys = Object.keys(this.diffCoverageReport);
-        for (const key of keys) {
-            const diffCoverageData = this.diffCoverageReport[key];
+        const changedFiles = Object.keys(this.diffCoverageReport);
+        for (const fileName of changedFiles) {
+            const diffCoverageData = this.diffCoverageReport[fileName];
             const keys = Object.keys(diffCoverageData);
             // No new coverage found so that means we deleted a file coverage
             const fileRemovedCoverage = Object.values(diffCoverageData).every(coverageData => coverageData.newPct === 0);
@@ -9877,7 +9879,8 @@ class DiffChecker {
             }
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
+                    const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
+                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9866,7 +9866,7 @@ class DiffChecker {
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
             funcPercentageDiff < 0 &&
-            funcPercentageDiff >= delta);
+            Math.abs(funcPercentageDiff) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
         const changedFiles = Object.keys(this.diffCoverageReport);
@@ -9882,7 +9882,7 @@ class DiffChecker {
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
                     const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff < 0 && percentageDiff >= delta) {
+                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,6 +9819,34 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
+        const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
+        for (const filePath of reportNewKeys) {
+            if (filePath === 'total')
+                continue;
+            temporaryReport[filePath] = coverageReportNew[filePath];
+        }
+        const total = {
+            lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
+        };
+        for (const key in temporaryReport) {
+            if (key === 'total')
+                continue;
+            const item = temporaryReport[key];
+            for (const metricType in item) {
+                const metric = item[metricType];
+                total[metricType]['total'] += metric.total;
+                total[metricType]['covered'] += metric.covered;
+                total[metricType]['skipped'] += metric.skipped;
+            }
+        }
+        for (const metricType in total) {
+            const metric = total[metricType];
+            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
+        }
+        coverageReportNew.total = total;
         console.log('New Report keys: ', coverageReportNew);
         console.log('Old Report keys: ', coverageReportOld);
         console.log('Report keys: ', reportKeys);

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,6 +9819,34 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
+        const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
+        for (const filePath of reportNewKeys) {
+            if (filePath === 'total')
+                continue;
+            temporaryReport[filePath] = coverageReportNew[filePath];
+        }
+        const total = {
+            lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
+        };
+        for (const key in temporaryReport) {
+            if (key === 'total')
+                continue;
+            const item = temporaryReport[key];
+            for (const metricType in item) {
+                const metric = item[metricType];
+                total[metricType]['total'] += metric.total;
+                total[metricType]['covered'] += metric.covered;
+                total[metricType]['skipped'] += metric.skipped;
+            }
+        }
+        for (const metricType in total) {
+            const metric = total[metricType];
+            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
+        }
+        coverageReportNew.total = total;
         for (const filePath of reportKeys) {
             this.diffCoverageReport[filePath] = {
                 branches: {
@@ -9857,14 +9885,16 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
+        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            -this.getPercentageDiff(total.functions) >= delta);
+            funcPercentageDiff < 0 &&
+            Math.abs(funcPercentageDiff) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
-        const keys = Object.keys(this.diffCoverageReport);
-        for (const key of keys) {
-            const diffCoverageData = this.diffCoverageReport[key];
+        const changedFiles = Object.keys(this.diffCoverageReport);
+        for (const fileName of changedFiles) {
+            const diffCoverageData = this.diffCoverageReport[fileName];
             const keys = Object.keys(diffCoverageData);
             // No new coverage found so that means we deleted a file coverage
             const fileRemovedCoverage = Object.values(diffCoverageData).every(coverageData => coverageData.newPct === 0);
@@ -9874,7 +9904,8 @@ class DiffChecker {
             }
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
+                    const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
+                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9820,11 +9820,6 @@ class DiffChecker {
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
         const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
-        for (const filePath of reportNewKeys) {
-            if (filePath === 'total')
-                continue;
-            temporaryReport[filePath] = coverageReportNew[filePath];
-        }
         const total = {
             lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
             statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
@@ -9890,7 +9885,7 @@ class DiffChecker {
         const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            Math.abs(funcPercentageDiff) >= delta);
+            funcPercentageDiff >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
         const changedFiles = Object.keys(this.diffCoverageReport);
@@ -9906,7 +9901,7 @@ class DiffChecker {
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
                     const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (Math.abs(percentageDiff) >= delta) {
+                    if (percentageDiff >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,55 +9819,25 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
-        const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
-        for (const filePath of reportNewKeys) {
-            if (filePath === 'total')
-                continue;
-            temporaryReport[filePath] = coverageReportNew[filePath];
-        }
-        const total = {
-            lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
-        };
-        for (const key in temporaryReport) {
-            if (key === 'total')
-                continue;
-            const item = temporaryReport[key];
-            for (const metricType in item) {
-                const metric = item[metricType];
-                total[metricType]['total'] += metric.total;
-                total[metricType]['covered'] += metric.covered;
-                total[metricType]['skipped'] += metric.skipped;
-            }
-        }
-        for (const metricType in total) {
-            const metric = total[metricType];
-            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
-        }
-        coverageReportNew.total = total;
         for (const filePath of reportKeys) {
-            if (reportNewKeys.includes(filePath)) {
-                this.diffCoverageReport[filePath] = {
-                    branches: {
-                        newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
-                        oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
-                    },
-                    statements: {
-                        newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
-                        oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
-                    },
-                    lines: {
-                        newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
-                        oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
-                    },
-                    functions: {
-                        newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
-                        oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
-                    }
-                };
-            }
+            this.diffCoverageReport[filePath] = {
+                branches: {
+                    newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
+                    oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
+                },
+                statements: {
+                    newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
+                    oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
+                },
+                lines: {
+                    newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
+                    oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
+                },
+                functions: {
+                    newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
+                    oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
+                }
+            };
         }
     }
     getCoverageDetails(diffOnly, currentDirectory, delta = 1) {
@@ -9887,16 +9857,14 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
-        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            funcPercentageDiff < 0 &&
-            Math.abs(funcPercentageDiff) >= delta);
+            -this.getPercentageDiff(total.functions) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
-        const changedFiles = Object.keys(this.diffCoverageReport);
-        for (const fileName of changedFiles) {
-            const diffCoverageData = this.diffCoverageReport[fileName];
+        const keys = Object.keys(this.diffCoverageReport);
+        for (const key of keys) {
+            const diffCoverageData = this.diffCoverageReport[key];
             const keys = Object.keys(diffCoverageData);
             // No new coverage found so that means we deleted a file coverage
             const fileRemovedCoverage = Object.values(diffCoverageData).every(coverageData => coverageData.newPct === 0);
@@ -9906,8 +9874,7 @@ class DiffChecker {
             }
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+                    if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9820,24 +9820,26 @@ class DiffChecker {
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
         for (const filePath of reportKeys) {
-            this.diffCoverageReport[filePath] = {
-                branches: {
-                    newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
-                    oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
-                },
-                statements: {
-                    newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
-                    oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
-                },
-                lines: {
-                    newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
-                    oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
-                },
-                functions: {
-                    newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
-                    oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
-                }
-            };
+            if (reportNewKeys.includes(filePath)) {
+                this.diffCoverageReport[filePath] = {
+                    branches: {
+                        newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
+                        oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
+                    },
+                    statements: {
+                        newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
+                        oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
+                    },
+                    lines: {
+                        newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
+                        oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
+                    },
+                    functions: {
+                        newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
+                        oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
+                    }
+                };
+            }
         }
     }
     getCoverageDetails(diffOnly, currentDirectory, delta = 1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9862,16 +9862,14 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
-        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            funcPercentageDiff < 0 &&
-            Math.abs(funcPercentageDiff) >= delta);
+            -this.getPercentageDiff(total.functions) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
-        const changedFiles = Object.keys(this.diffCoverageReport);
-        for (const fileName of changedFiles) {
-            const diffCoverageData = this.diffCoverageReport[fileName];
+        const keys = Object.keys(this.diffCoverageReport);
+        for (const key of keys) {
+            const diffCoverageData = this.diffCoverageReport[key];
             const keys = Object.keys(diffCoverageData);
             // No new coverage found so that means we deleted a file coverage
             const fileRemovedCoverage = Object.values(diffCoverageData).every(coverageData => coverageData.newPct === 0);
@@ -9881,8 +9879,7 @@ class DiffChecker {
             }
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+                    if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,23 +9819,52 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
-        for (const filePath of reportKeys) {
+        const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
+        for (const filePath of reportNewKeys) {
+            if (filePath === 'total')
+                continue;
+            temporaryReport[filePath] = coverageReportNew[filePath];
+        }
+        const total = {
+            lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
+        };
+        for (const key in temporaryReport) {
+            if (key === 'total')
+                continue;
+            const item = temporaryReport[key];
+            for (const metricType in item) {
+                const metric = item[metricType];
+                total[metricType]['total'] += metric.total;
+                total[metricType]['covered'] += metric.covered;
+                total[metricType]['skipped'] += metric.skipped;
+            }
+        }
+        for (const metricType in total) {
+            const metric = total[metricType];
+            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
+        }
+        coverageReportNew.total = total;
+        for (const filePath of reportOldKeys) {
+            // Include file from coverageReportOld in diffCoverageReport
             this.diffCoverageReport[filePath] = {
                 branches: {
-                    newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
-                    oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
+                    newPct: this.getPercentage((_a = coverageReportNew.total) === null || _a === void 0 ? void 0 : _a.branches),
+                    oldPct: this.getPercentage((_b = coverageReportOld.total) === null || _b === void 0 ? void 0 : _b.branches)
                 },
                 statements: {
-                    newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
-                    oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
+                    newPct: this.getPercentage((_c = coverageReportNew.total) === null || _c === void 0 ? void 0 : _c.statements),
+                    oldPct: this.getPercentage((_d = coverageReportOld.total) === null || _d === void 0 ? void 0 : _d.statements)
                 },
                 lines: {
-                    newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
-                    oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
+                    newPct: this.getPercentage((_e = coverageReportNew.total) === null || _e === void 0 ? void 0 : _e.lines),
+                    oldPct: this.getPercentage((_f = coverageReportOld.total) === null || _f === void 0 ? void 0 : _f.lines)
                 },
                 functions: {
-                    newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
-                    oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
+                    newPct: this.getPercentage((_g = coverageReportNew.total) === null || _g === void 0 ? void 0 : _g.functions),
+                    oldPct: this.getPercentage((_h = coverageReportOld.total) === null || _h === void 0 ? void 0 : _h.functions)
                 }
             };
         }
@@ -9857,14 +9886,16 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
+        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            -this.getPercentageDiff(total.functions) >= delta);
+            funcPercentageDiff < 0 &&
+            Math.abs(funcPercentageDiff) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
-        const keys = Object.keys(this.diffCoverageReport);
-        for (const key of keys) {
-            const diffCoverageData = this.diffCoverageReport[key];
+        const changedFiles = Object.keys(this.diffCoverageReport);
+        for (const fileName of changedFiles) {
+            const diffCoverageData = this.diffCoverageReport[fileName];
             const keys = Object.keys(diffCoverageData);
             // No new coverage found so that means we deleted a file coverage
             const fileRemovedCoverage = Object.values(diffCoverageData).every(coverageData => coverageData.newPct === 0);
@@ -9874,7 +9905,8 @@ class DiffChecker {
             }
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
+                    const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
+                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9847,11 +9847,11 @@ class DiffChecker {
             metric.pct = (metric.covered / metric.total) * 100;
         }
         coverageReportNew.total = total;
-        console.log('Old Report Total: ', coverageReportOld['total']);
-        console.log('New Report Total: ', coverageReportNew['total']);
         for (const filePath of reportKeys) {
             if (reportNewKeys.includes(filePath)) {
-                console.log('Old Report keys: ', coverageReportOld[filePath]);
+                console.log(`__________ ${filePath} _________`);
+                console.log(`>> Old Report: <<'`, coverageReportOld[filePath]);
+                console.log(`>>> New Report: <<<'`, coverageReportNew[filePath]);
                 this.diffCoverageReport[filePath] = {
                     branches: {
                         newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
@@ -9870,7 +9870,7 @@ class DiffChecker {
                         oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
                     }
                 };
-                console.log('---- DIFF : ------', this.diffCoverageReport[filePath]);
+                console.log(`-- DIF: --`, this.diffCoverageReport[filePath]);
             }
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,6 +9819,34 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
+        const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
+        for (const filePath of reportNewKeys) {
+            if (filePath === 'total')
+                continue;
+            temporaryReport[filePath] = coverageReportNew[filePath];
+        }
+        const total = {
+            lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+            branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
+        };
+        for (const key in temporaryReport) {
+            if (key !== 'total')
+                continue;
+            const item = temporaryReport[key];
+            for (const metricType in item) {
+                const metric = item[metricType];
+                total[metricType]['total'] += Number(metric.total);
+                total[metricType]['covered'] += Number(metric.covered);
+                total[metricType]['skipped'] += Number(metric.skipped);
+            }
+        }
+        for (const metricType in total) {
+            const metric = total[metricType];
+            metric.pct = Math.floor((metric.covered / metric.total) * 100);
+        }
+        coverageReportNew.total = total;
         for (const filePath of reportKeys) {
             if (reportNewKeys.includes(filePath)) {
                 this.diffCoverageReport[filePath] = {
@@ -9859,14 +9887,15 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
+        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            -this.getPercentageDiff(total.functions) >= delta);
+            Math.abs(funcPercentageDiff) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
-        const keys = Object.keys(this.diffCoverageReport);
-        for (const key of keys) {
-            const diffCoverageData = this.diffCoverageReport[key];
+        const changedFiles = Object.keys(this.diffCoverageReport);
+        for (const fileName of changedFiles) {
+            const diffCoverageData = this.diffCoverageReport[fileName];
             const keys = Object.keys(diffCoverageData);
             // No new coverage found so that means we deleted a file coverage
             const fileRemovedCoverage = Object.values(diffCoverageData).every(coverageData => coverageData.newPct === 0);
@@ -9876,7 +9905,8 @@ class DiffChecker {
             }
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
+                    const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
+                    if (Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9844,7 +9844,12 @@ class DiffChecker {
         }
         for (const metricType in total) {
             const metric = total[metricType];
-            metric.pct = +(metric.covered / metric.total).toFixed(2) * 100;
+            const relation = metric.covered / metric.total;
+            const matchResult = (relation * 100)
+                .toString()
+                .match(/^-?\d+(?:\.\d{0,2})?/);
+            const result = matchResult ? matchResult[0] : '';
+            metric.pct = +result;
         }
         coverageReportNew.total = total;
         for (const filePath of reportKeys) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,37 +9819,9 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
-        console.log('New Report keys: ', reportNewKeys);
-        console.log('Old Report keys: ', reportOldKeys);
+        console.log('New Report keys: ', coverageReportNew);
+        console.log('Old Report keys: ', coverageReportOld);
         console.log('Report keys: ', reportKeys);
-        const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
-        for (const filePath of reportNewKeys) {
-            if (filePath === 'total')
-                continue;
-            temporaryReport[filePath] = coverageReportNew[filePath];
-        }
-        const total = {
-            lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
-        };
-        for (const key in temporaryReport) {
-            if (key === 'total')
-                continue;
-            const item = temporaryReport[key];
-            for (const metricType in item) {
-                const metric = item[metricType];
-                total[metricType]['total'] += metric.total;
-                total[metricType]['covered'] += metric.covered;
-                total[metricType]['skipped'] += metric.skipped;
-            }
-        }
-        for (const metricType in total) {
-            const metric = total[metricType];
-            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
-        }
-        coverageReportNew.total = total;
         for (const filePath of reportKeys) {
             if (reportNewKeys.includes(filePath)) {
                 this.diffCoverageReport[filePath] = {
@@ -9894,7 +9866,7 @@ class DiffChecker {
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
             funcPercentageDiff < 0 &&
-            Math.abs(funcPercentageDiff) >= delta);
+            funcPercentageDiff >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
         const changedFiles = Object.keys(this.diffCoverageReport);
@@ -9910,7 +9882,7 @@ class DiffChecker {
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
                     const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+                    if (percentageDiff < 0 && percentageDiff >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9820,6 +9820,11 @@ class DiffChecker {
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
         const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
+        for (const filePath of reportNewKeys) {
+            if (filePath === 'total')
+                continue;
+            temporaryReport[filePath] = coverageReportNew[filePath];
+        }
         const total = {
             lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
             statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
@@ -9827,7 +9832,7 @@ class DiffChecker {
             branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
         };
         for (const key in temporaryReport) {
-            if (key !== 'total')
+            if (key === 'total')
                 continue;
             const item = temporaryReport[key];
             for (const metricType in item) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9844,7 +9844,7 @@ class DiffChecker {
         }
         for (const metricType in total) {
             const metric = total[metricType];
-            metric.pct = Math.round((metric.covered / metric.total) * 100);
+            metric.pct = (metric.covered / metric.total) * 100;
         }
         coverageReportNew.total = total;
         for (const filePath of reportKeys) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9823,26 +9823,24 @@ class DiffChecker {
         console.log('Old Report keys: ', coverageReportOld);
         console.log('Report keys: ', reportKeys);
         for (const filePath of reportKeys) {
-            if (reportNewKeys.includes(filePath)) {
-                this.diffCoverageReport[filePath] = {
-                    branches: {
-                        newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
-                        oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
-                    },
-                    statements: {
-                        newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
-                        oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
-                    },
-                    lines: {
-                        newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
-                        oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
-                    },
-                    functions: {
-                        newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
-                        oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
-                    }
-                };
-            }
+            this.diffCoverageReport[filePath] = {
+                branches: {
+                    newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
+                    oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
+                },
+                statements: {
+                    newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
+                    oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
+                },
+                lines: {
+                    newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
+                    oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
+                },
+                functions: {
+                    newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
+                    oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
+                }
+            };
         }
     }
     getCoverageDetails(diffOnly, currentDirectory, delta = 1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9922,7 +9922,7 @@ class DiffChecker {
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
                     const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+                    if (percentageDiff <= 0 && Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,6 +9819,9 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
+        console.log('New Report keys: ', reportNewKeys);
+        console.log('Old Report keys: ', reportOldKeys);
+        console.log('Report keys: ', reportKeys);
         const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
         for (const filePath of reportNewKeys) {
             if (filePath === 'total')
@@ -9837,14 +9840,14 @@ class DiffChecker {
             const item = temporaryReport[key];
             for (const metricType in item) {
                 const metric = item[metricType];
-                total[metricType]['total'] += Number(metric.total);
-                total[metricType]['covered'] += Number(metric.covered);
-                total[metricType]['skipped'] += Number(metric.skipped);
+                total[metricType]['total'] += metric.total;
+                total[metricType]['covered'] += metric.covered;
+                total[metricType]['skipped'] += metric.skipped;
             }
         }
         for (const metricType in total) {
             const metric = total[metricType];
-            metric.pct = Math.floor((metric.covered / metric.total) * 100);
+            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
         }
         coverageReportNew.total = total;
         for (const filePath of reportKeys) {
@@ -9890,7 +9893,8 @@ class DiffChecker {
         const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            funcPercentageDiff >= delta);
+            funcPercentageDiff < 0 &&
+            Math.abs(funcPercentageDiff) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
         const changedFiles = Object.keys(this.diffCoverageReport);
@@ -9906,7 +9910,7 @@ class DiffChecker {
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
                     const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff >= delta) {
+                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9852,7 +9852,6 @@ class DiffChecker {
         for (const filePath of reportKeys) {
             if (reportNewKeys.includes(filePath)) {
                 console.log('Old Report keys: ', coverageReportOld[filePath]);
-                console.log('---- DIFF : ------', this.diffCoverageReport[filePath]);
                 this.diffCoverageReport[filePath] = {
                     branches: {
                         newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
@@ -9871,6 +9870,7 @@ class DiffChecker {
                         oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
                     }
                 };
+                console.log('---- DIFF : ------', this.diffCoverageReport[filePath]);
             }
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9922,7 +9922,7 @@ class DiffChecker {
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
                     const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff <= 0 && Math.abs(percentageDiff) >= delta) {
+                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9823,24 +9823,26 @@ class DiffChecker {
         console.log('Old Report keys: ', coverageReportOld);
         console.log('Report keys: ', reportKeys);
         for (const filePath of reportKeys) {
-            this.diffCoverageReport[filePath] = {
-                branches: {
-                    newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
-                    oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
-                },
-                statements: {
-                    newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
-                    oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
-                },
-                lines: {
-                    newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
-                    oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
-                },
-                functions: {
-                    newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
-                    oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
-                }
-            };
+            if (reportNewKeys.includes(filePath)) {
+                this.diffCoverageReport[filePath] = {
+                    branches: {
+                        newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
+                        oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
+                    },
+                    statements: {
+                        newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
+                        oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
+                    },
+                    lines: {
+                        newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
+                        oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
+                    },
+                    functions: {
+                        newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
+                        oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
+                    }
+                };
+            }
         }
     }
     getCoverageDetails(diffOnly, currentDirectory, delta = 1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9819,34 +9819,6 @@ class DiffChecker {
         const reportNewKeys = Object.keys(coverageReportNew);
         const reportOldKeys = Object.keys(coverageReportOld);
         const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
-        const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld));
-        for (const filePath of reportNewKeys) {
-            if (filePath === 'total')
-                continue;
-            temporaryReport[filePath] = coverageReportNew[filePath];
-        }
-        const total = {
-            lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
-            branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
-        };
-        for (const key in temporaryReport) {
-            if (key === 'total')
-                continue;
-            const item = temporaryReport[key];
-            for (const metricType in item) {
-                const metric = item[metricType];
-                total[metricType]['total'] += metric.total;
-                total[metricType]['covered'] += metric.covered;
-                total[metricType]['skipped'] += metric.skipped;
-            }
-        }
-        for (const metricType in total) {
-            const metric = total[metricType];
-            metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100;
-        }
-        coverageReportNew.total = total;
         for (const filePath of reportKeys) {
             this.diffCoverageReport[filePath] = {
                 branches: {
@@ -9885,16 +9857,14 @@ class DiffChecker {
     }
     checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta) {
         const { total } = this.diffCoverageReport;
-        const funcPercentageDiff = this.getPercentageDiff(total.functions);
         return (total &&
             total.functions.oldPct !== total.functions.newPct &&
-            funcPercentageDiff < 0 &&
-            Math.abs(funcPercentageDiff) >= delta);
+            -this.getPercentageDiff(total.functions) >= delta);
     }
     checkIfTestCoverageFallsBelowDelta(delta) {
-        const changedFiles = Object.keys(this.diffCoverageReport);
-        for (const fileName of changedFiles) {
-            const diffCoverageData = this.diffCoverageReport[fileName];
+        const keys = Object.keys(this.diffCoverageReport);
+        for (const key of keys) {
+            const diffCoverageData = this.diffCoverageReport[key];
             const keys = Object.keys(diffCoverageData);
             // No new coverage found so that means we deleted a file coverage
             const fileRemovedCoverage = Object.values(diffCoverageData).every(coverageData => coverageData.newPct === 0);
@@ -9904,8 +9874,7 @@ class DiffChecker {
             }
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    const percentageDiff = this.getPercentageDiff(diffCoverageData[key]);
-                    if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+                    if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9844,7 +9844,7 @@ class DiffChecker {
         }
         for (const metricType in total) {
             const metric = total[metricType];
-            metric.pct = (metric.covered / metric.total) * 100;
+            metric.pct = Math.round((metric.covered / metric.total) * 100);
         }
         coverageReportNew.total = total;
         for (const filePath of reportKeys) {

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -152,7 +152,7 @@ export class DiffChecker {
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
           const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff <= 0 && Math.abs(percentageDiff) >= delta) {
+          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -45,7 +45,7 @@ export class DiffChecker {
 
     for (const metricType in total) {
       const metric = total[metricType]
-      metric.pct = ((metric.covered / metric.total) * 100).toFixed(2)
+      metric.pct = +(metric.covered / metric.total).toFixed(2) * 100
     }
 
     coverageReportNew.total = <FileCoverageData>total

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -152,7 +152,7 @@ export class DiffChecker {
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
           const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+          if (percentageDiff <= 0 && Math.abs(percentageDiff) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -3,7 +3,6 @@ import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
 import {DiffFileCoverageData} from './Model/DiffFileCoverageData'
 import {DiffCoverageData} from './Model/DiffCoverageData'
-import {FileCoverageData} from './Model/FileCoverageData'
 
 const increasedCoverageIcon = ':green_circle::dog:'
 const decreasedCoverageIcon = ':red_circle:'
@@ -20,54 +19,23 @@ export class DiffChecker {
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
-    const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
-    for (const filePath of reportNewKeys) {
-      if (filePath === 'total') continue
-      temporaryReport[filePath] = coverageReportNew[filePath]
-    }
-    const total: {[index: string]: any} = {
-      lines: {total: 0, covered: 0, skipped: 0, pct: 0},
-      statements: {total: 0, covered: 0, skipped: 0, pct: 0},
-      functions: {total: 0, covered: 0, skipped: 0, pct: 0},
-      branches: {total: 0, covered: 0, skipped: 0, pct: 0}
-    }
-    for (const key in temporaryReport) {
-      if (key === 'total') continue
-      const item = temporaryReport[key]
-      for (const metricType in item) {
-        const metric = item[metricType]
-        total[metricType]['total'] += metric.total
-        total[metricType]['covered'] += metric.covered
-        total[metricType]['skipped'] += metric.skipped
-      }
-    }
-
-    for (const metricType in total) {
-      const metric = total[metricType]
-      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
-    }
-
-    coverageReportNew.total = <FileCoverageData>total
-
     for (const filePath of reportKeys) {
-      if (reportNewKeys.includes(filePath)) {
-        this.diffCoverageReport[filePath] = {
-          branches: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
-          },
-          statements: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
-          },
-          lines: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
-          },
-          functions: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
-          }
+      this.diffCoverageReport[filePath] = {
+        branches: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
+        },
+        statements: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
+        },
+        lines: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
+        },
+        functions: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
         }
       }
     }
@@ -106,19 +74,17 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
-    const funcPercentageDiff = this.getPercentageDiff(total.functions)
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      funcPercentageDiff < 0 &&
-      Math.abs(funcPercentageDiff) >= delta
+      -this.getPercentageDiff(total.functions) >= delta
     )
   }
 
   checkIfTestCoverageFallsBelowDelta(delta: number): boolean {
-    const changedFiles = Object.keys(this.diffCoverageReport)
-    for (const fileName of changedFiles) {
-      const diffCoverageData = this.diffCoverageReport[fileName]
+    const keys = Object.keys(this.diffCoverageReport)
+    for (const key of keys) {
+      const diffCoverageData = this.diffCoverageReport[key]
       const keys: ('lines' | 'statements' | 'branches' | 'functions')[] = <
         ('lines' | 'statements' | 'branches' | 'functions')[]
       >Object.keys(diffCoverageData)
@@ -132,8 +98,7 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+          if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -21,16 +21,14 @@ export class DiffChecker {
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
-    for (const filePath of reportNewKeys) {
-      if (filePath === 'total') continue
-      temporaryReport[filePath] = coverageReportNew[filePath]
-    }
+
     const total: {[index: string]: any} = {
       lines: {total: 0, covered: 0, skipped: 0, pct: 0},
       statements: {total: 0, covered: 0, skipped: 0, pct: 0},
       functions: {total: 0, covered: 0, skipped: 0, pct: 0},
       branches: {total: 0, covered: 0, skipped: 0, pct: 0}
     }
+
     for (const key in temporaryReport) {
       if (key !== 'total') continue
       const item = temporaryReport[key]
@@ -110,7 +108,7 @@ export class DiffChecker {
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      Math.abs(funcPercentageDiff) >= delta
+      funcPercentageDiff >= delta
     )
   }
 
@@ -132,7 +130,7 @@ export class DiffChecker {
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
           const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (Math.abs(percentageDiff) >= delta) {
+          if (percentageDiff >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -21,38 +21,9 @@ export class DiffChecker {
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
-    console.log('New Report keys: ', reportNewKeys)
-    console.log('Old Report keys: ', reportOldKeys)
+    console.log('New Report keys: ', coverageReportNew)
+    console.log('Old Report keys: ', coverageReportOld)
     console.log('Report keys: ', reportKeys)
-
-    const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
-    for (const filePath of reportNewKeys) {
-      if (filePath === 'total') continue
-      temporaryReport[filePath] = coverageReportNew[filePath]
-    }
-    const total: {[index: string]: any} = {
-      lines: {total: 0, covered: 0, skipped: 0, pct: 0},
-      statements: {total: 0, covered: 0, skipped: 0, pct: 0},
-      functions: {total: 0, covered: 0, skipped: 0, pct: 0},
-      branches: {total: 0, covered: 0, skipped: 0, pct: 0}
-    }
-    for (const key in temporaryReport) {
-      if (key === 'total') continue
-      const item = temporaryReport[key]
-      for (const metricType in item) {
-        const metric = item[metricType]
-        total[metricType]['total'] += metric.total
-        total[metricType]['covered'] += metric.covered
-        total[metricType]['skipped'] += metric.skipped
-      }
-    }
-
-    for (const metricType in total) {
-      const metric = total[metricType]
-      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
-    }
-
-    coverageReportNew.total = <FileCoverageData>total
 
     for (const filePath of reportKeys) {
       if (reportNewKeys.includes(filePath)) {
@@ -116,7 +87,7 @@ export class DiffChecker {
       total &&
       total.functions.oldPct !== total.functions.newPct &&
       funcPercentageDiff < 0 &&
-      Math.abs(funcPercentageDiff) >= delta
+      funcPercentageDiff >= delta
     )
   }
 
@@ -138,7 +109,7 @@ export class DiffChecker {
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
           const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+          if (percentageDiff < 0 && percentageDiff >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -45,7 +45,7 @@ export class DiffChecker {
 
     for (const metricType in total) {
       const metric = total[metricType]
-      metric.pct = (metric.covered / metric.total) * 100
+      metric.pct = ((metric.covered / metric.total) * 100).toFixed(2)
     }
 
     coverageReportNew.total = <FileCoverageData>total

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import {CoverageReport} from './Model/CoverageReport'
 import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
@@ -20,6 +21,10 @@ export class DiffChecker {
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
+    console.log('New Report keys: ', reportNewKeys)
+    console.log('Old Report keys: ', reportOldKeys)
+    console.log('Report keys: ', reportKeys)
+
     const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
     for (const filePath of reportNewKeys) {
       if (filePath === 'total') continue
@@ -36,15 +41,15 @@ export class DiffChecker {
       const item = temporaryReport[key]
       for (const metricType in item) {
         const metric = item[metricType]
-        total[metricType]['total'] += Number(metric.total)
-        total[metricType]['covered'] += Number(metric.covered)
-        total[metricType]['skipped'] += Number(metric.skipped)
+        total[metricType]['total'] += metric.total
+        total[metricType]['covered'] += metric.covered
+        total[metricType]['skipped'] += metric.skipped
       }
     }
 
     for (const metricType in total) {
       const metric = total[metricType]
-      metric.pct = Math.floor((metric.covered / metric.total) * 100)
+      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
     }
 
     coverageReportNew.total = <FileCoverageData>total
@@ -110,7 +115,8 @@ export class DiffChecker {
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      funcPercentageDiff >= delta
+      funcPercentageDiff < 0 &&
+      Math.abs(funcPercentageDiff) >= delta
     )
   }
 
@@ -132,7 +138,7 @@ export class DiffChecker {
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
           const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff >= delta) {
+          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -45,7 +45,7 @@ export class DiffChecker {
 
     for (const metricType in total) {
       const metric = total[metricType]
-      metric.pct = (metric.covered / metric.total) * 100
+      metric.pct = Math.round((metric.covered / metric.total) * 100)
     }
 
     coverageReportNew.total = <FileCoverageData>total

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -21,16 +21,18 @@ export class DiffChecker {
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
-
+    for (const filePath of reportNewKeys) {
+      if (filePath === 'total') continue
+      temporaryReport[filePath] = coverageReportNew[filePath]
+    }
     const total: {[index: string]: any} = {
       lines: {total: 0, covered: 0, skipped: 0, pct: 0},
       statements: {total: 0, covered: 0, skipped: 0, pct: 0},
       functions: {total: 0, covered: 0, skipped: 0, pct: 0},
       branches: {total: 0, covered: 0, skipped: 0, pct: 0}
     }
-
     for (const key in temporaryReport) {
-      if (key !== 'total') continue
+      if (key === 'total') continue
       const item = temporaryReport[key]
       for (const metricType in item) {
         const metric = item[metricType]

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -21,6 +21,35 @@ export class DiffChecker {
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
+    const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
+    for (const filePath of reportNewKeys) {
+      if (filePath === 'total') continue
+      temporaryReport[filePath] = coverageReportNew[filePath]
+    }
+    const total: {[index: string]: any} = {
+      lines: {total: 0, covered: 0, skipped: 0, pct: 0},
+      statements: {total: 0, covered: 0, skipped: 0, pct: 0},
+      functions: {total: 0, covered: 0, skipped: 0, pct: 0},
+      branches: {total: 0, covered: 0, skipped: 0, pct: 0}
+    }
+    for (const key in temporaryReport) {
+      if (key === 'total') continue
+      const item = temporaryReport[key]
+      for (const metricType in item) {
+        const metric = item[metricType]
+        total[metricType]['total'] += metric.total
+        total[metricType]['covered'] += metric.covered
+        total[metricType]['skipped'] += metric.skipped
+      }
+    }
+
+    for (const metricType in total) {
+      const metric = total[metricType]
+      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
+    }
+
+    coverageReportNew.total = <FileCoverageData>total
+
     console.log('New Report keys: ', coverageReportNew)
     console.log('Old Report keys: ', coverageReportOld)
     console.log('Report keys: ', reportKeys)

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -121,14 +121,10 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
-    const comparison = {
-      oldPct: total.functions.oldCovered,
-      newPct: total.functions.newCovered
-    }
-    const funcPercentageDiff = this.getPercentageDiff(comparison)
+    const funcPercentageDiff = this.getPercentageDiff(total.functions)
     return (
       total &&
-      total.functions.oldCovered !== total.functions.newCovered &&
+      total.functions.oldPct !== total.functions.newPct &&
       funcPercentageDiff < 0 &&
       Math.abs(funcPercentageDiff) >= delta
     )

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -3,6 +3,7 @@ import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
 import {DiffFileCoverageData} from './Model/DiffFileCoverageData'
 import {DiffCoverageData} from './Model/DiffCoverageData'
+import {FileCoverageData} from './Model/FileCoverageData'
 
 const increasedCoverageIcon = ':green_circle::dog:'
 const decreasedCoverageIcon = ':red_circle:'
@@ -18,6 +19,35 @@ export class DiffChecker {
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
+
+    const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
+    for (const filePath of reportNewKeys) {
+      if (filePath === 'total') continue
+      temporaryReport[filePath] = coverageReportNew[filePath]
+    }
+    const total: {[index: string]: any} = {
+      lines: {total: 0, covered: 0, skipped: 0, pct: 0},
+      statements: {total: 0, covered: 0, skipped: 0, pct: 0},
+      functions: {total: 0, covered: 0, skipped: 0, pct: 0},
+      branches: {total: 0, covered: 0, skipped: 0, pct: 0}
+    }
+    for (const key in temporaryReport) {
+      if (key === 'total') continue
+      const item = temporaryReport[key]
+      for (const metricType in item) {
+        const metric = item[metricType]
+        total[metricType]['total'] += metric.total
+        total[metricType]['covered'] += metric.covered
+        total[metricType]['skipped'] += metric.skipped
+      }
+    }
+
+    for (const metricType in total) {
+      const metric = total[metricType]
+      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
+    }
+
+    coverageReportNew.total = <FileCoverageData>total
 
     for (const filePath of reportKeys) {
       this.diffCoverageReport[filePath] = {
@@ -74,17 +104,19 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
+    const funcPercentageDiff = this.getPercentageDiff(total.functions)
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      -this.getPercentageDiff(total.functions) >= delta
+      funcPercentageDiff < 0 &&
+      Math.abs(funcPercentageDiff) >= delta
     )
   }
 
   checkIfTestCoverageFallsBelowDelta(delta: number): boolean {
-    const keys = Object.keys(this.diffCoverageReport)
-    for (const key of keys) {
-      const diffCoverageData = this.diffCoverageReport[key]
+    const changedFiles = Object.keys(this.diffCoverageReport)
+    for (const fileName of changedFiles) {
+      const diffCoverageData = this.diffCoverageReport[fileName]
       const keys: ('lines' | 'statements' | 'branches' | 'functions')[] = <
         ('lines' | 'statements' | 'branches' | 'functions')[]
       >Object.keys(diffCoverageData)
@@ -98,7 +130,8 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
+          const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
+          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -37,21 +37,27 @@ export class DiffChecker {
       const item = temporaryReport[key]
       for (const metricType in item) {
         const metric = item[metricType]
-        total[metricType]['total'] += metric.total
-        total[metricType]['covered'] += metric.covered
-        total[metricType]['skipped'] += metric.skipped
+        total[metricType]['total'] += Number(metric.total)
+        total[metricType]['covered'] += Number(metric.covered)
+        total[metricType]['skipped'] += Number(metric.skipped)
       }
     }
 
     for (const metricType in total) {
       const metric = total[metricType]
-      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
+      metric.pct = (metric.covered / metric.total) * 100
     }
 
     coverageReportNew.total = <FileCoverageData>total
 
     console.log('New Report keys: ', coverageReportNew)
-    console.log('Old Report keys: ', coverageReportOld)
+    console.log(
+      'Old Report keys: ',
+      coverageReportOld[
+        '/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts'
+      ]
+    )
+    console.log('Old Report keys: ', coverageReportOld['total'])
     console.log('Report keys: ', reportKeys)
 
     for (const filePath of reportKeys) {
@@ -74,6 +80,11 @@ export class DiffChecker {
             oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
           }
         }
+        if (
+          filePath ===
+          '/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts'
+        )
+          console.log('----HEYHEY ------', this.diffCoverageReport[filePath])
       }
     }
   }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -3,6 +3,7 @@ import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
 import {DiffFileCoverageData} from './Model/DiffFileCoverageData'
 import {DiffCoverageData} from './Model/DiffCoverageData'
+import {FileCoverageData} from './Model/FileCoverageData'
 
 const increasedCoverageIcon = ':green_circle::dog:'
 const decreasedCoverageIcon = ':red_circle:'
@@ -19,23 +20,53 @@ export class DiffChecker {
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
-    for (const filePath of reportKeys) {
+    const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
+    for (const filePath of reportNewKeys) {
+      if (filePath === 'total') continue
+      temporaryReport[filePath] = coverageReportNew[filePath]
+    }
+    const total: {[index: string]: any} = {
+      lines: {total: 0, covered: 0, skipped: 0, pct: 0},
+      statements: {total: 0, covered: 0, skipped: 0, pct: 0},
+      functions: {total: 0, covered: 0, skipped: 0, pct: 0},
+      branches: {total: 0, covered: 0, skipped: 0, pct: 0}
+    }
+    for (const key in temporaryReport) {
+      if (key === 'total') continue
+      const item = temporaryReport[key]
+      for (const metricType in item) {
+        const metric = item[metricType]
+        total[metricType]['total'] += metric.total
+        total[metricType]['covered'] += metric.covered
+        total[metricType]['skipped'] += metric.skipped
+      }
+    }
+
+    for (const metricType in total) {
+      const metric = total[metricType]
+      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
+    }
+
+    coverageReportNew.total = <FileCoverageData>total
+
+    for (const filePath of reportOldKeys) {
+      // Include file from coverageReportOld in diffCoverageReport
       this.diffCoverageReport[filePath] = {
         branches: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
+          newPct: this.getPercentage(coverageReportNew.total?.branches),
+          oldPct: this.getPercentage(coverageReportOld.total?.branches)
         },
         statements: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
+          newPct: this.getPercentage(coverageReportNew.total?.statements),
+          oldPct: this.getPercentage(coverageReportOld.total?.statements)
         },
         lines: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
+          newPct: this.getPercentage(coverageReportNew.total?.lines),
+          oldPct: this.getPercentage(coverageReportOld.total?.lines)
         },
         functions: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
+          newPct: this.getPercentage(coverageReportNew.total?.functions),
+          oldPct: this.getPercentage(coverageReportOld.total?.functions)
         }
       }
     }
@@ -74,17 +105,19 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
+    const funcPercentageDiff = this.getPercentageDiff(total.functions)
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      -this.getPercentageDiff(total.functions) >= delta
+      funcPercentageDiff < 0 &&
+      Math.abs(funcPercentageDiff) >= delta
     )
   }
 
   checkIfTestCoverageFallsBelowDelta(delta: number): boolean {
-    const keys = Object.keys(this.diffCoverageReport)
-    for (const key of keys) {
-      const diffCoverageData = this.diffCoverageReport[key]
+    const changedFiles = Object.keys(this.diffCoverageReport)
+    for (const fileName of changedFiles) {
+      const diffCoverageData = this.diffCoverageReport[fileName]
       const keys: ('lines' | 'statements' | 'branches' | 'functions')[] = <
         ('lines' | 'statements' | 'branches' | 'functions')[]
       >Object.keys(diffCoverageData)
@@ -98,7 +131,8 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
+          const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
+          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -4,7 +4,6 @@ import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
 import {DiffFileCoverageData} from './Model/DiffFileCoverageData'
 import {DiffCoverageData} from './Model/DiffCoverageData'
-import {FileCoverageData} from './Model/FileCoverageData'
 
 const increasedCoverageIcon = ':green_circle::dog:'
 const decreasedCoverageIcon = ':red_circle:'
@@ -48,7 +47,6 @@ export class DiffChecker {
       }
     }
   }
-
   getCoverageDetails(
     diffOnly: boolean,
     currentDirectory: string,
@@ -82,19 +80,17 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
-    const funcPercentageDiff = this.getPercentageDiff(total.functions)
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      funcPercentageDiff < 0 &&
-      Math.abs(funcPercentageDiff) >= delta
+      -this.getPercentageDiff(total.functions) >= delta
     )
   }
 
   checkIfTestCoverageFallsBelowDelta(delta: number): boolean {
-    const changedFiles = Object.keys(this.diffCoverageReport)
-    for (const fileName of changedFiles) {
-      const diffCoverageData = this.diffCoverageReport[fileName]
+    const keys = Object.keys(this.diffCoverageReport)
+    for (const key of keys) {
+      const diffCoverageData = this.diffCoverageReport[key]
       const keys: ('lines' | 'statements' | 'branches' | 'functions')[] = <
         ('lines' | 'statements' | 'branches' | 'functions')[]
       >Object.keys(diffCoverageData)
@@ -108,8 +104,7 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+          if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -26,22 +26,24 @@ export class DiffChecker {
     console.log('Report keys: ', reportKeys)
 
     for (const filePath of reportKeys) {
-      this.diffCoverageReport[filePath] = {
-        branches: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
-        },
-        statements: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
-        },
-        lines: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
-        },
-        functions: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
+      if (reportNewKeys.includes(filePath)) {
+        this.diffCoverageReport[filePath] = {
+          branches: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
+          },
+          statements: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
+          },
+          lines: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
+          },
+          functions: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
+          }
         }
       }
     }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -87,7 +87,7 @@ export class DiffChecker {
       total &&
       total.functions.oldPct !== total.functions.newPct &&
       funcPercentageDiff < 0 &&
-      funcPercentageDiff >= delta
+      Math.abs(funcPercentageDiff) >= delta
     )
   }
 
@@ -109,7 +109,7 @@ export class DiffChecker {
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
           const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff < 0 && percentageDiff >= delta) {
+          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -45,7 +45,14 @@ export class DiffChecker {
 
     for (const metricType in total) {
       const metric = total[metricType]
-      metric.pct = +(metric.covered / metric.total).toFixed(2) * 100
+      const relation = metric.covered / metric.total
+      const matchResult = (relation * 100)
+        .toString()
+        .match(/^-?\d+(?:\.\d{0,2})?/)
+
+      const result = matchResult ? matchResult[0] : ''
+
+      metric.pct = +result
     }
 
     coverageReportNew.total = <FileCoverageData>total

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -121,10 +121,14 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
-    const funcPercentageDiff = this.getPercentageDiff(total.functions)
+    const comparison = {
+      oldPct: total.functions.oldCovered,
+      newPct: total.functions.newCovered
+    }
+    const funcPercentageDiff = this.getPercentageDiff(comparison)
     return (
       total &&
-      total.functions.oldPct !== total.functions.newPct &&
+      total.functions.oldCovered !== total.functions.newCovered &&
       funcPercentageDiff < 0 &&
       Math.abs(funcPercentageDiff) >= delta
     )

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -45,7 +45,7 @@ export class DiffChecker {
 
     for (const metricType in total) {
       const metric = total[metricType]
-      metric.pct = Math.round((metric.covered / metric.total) * 100)
+      metric.pct = (metric.covered / metric.total) * 100
     }
 
     coverageReportNew.total = <FileCoverageData>total

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -3,7 +3,6 @@ import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
 import {DiffFileCoverageData} from './Model/DiffFileCoverageData'
 import {DiffCoverageData} from './Model/DiffCoverageData'
-import {FileCoverageData} from './Model/FileCoverageData'
 
 const increasedCoverageIcon = ':green_circle::dog:'
 const decreasedCoverageIcon = ':red_circle:'
@@ -20,53 +19,23 @@ export class DiffChecker {
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
-    const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
-    for (const filePath of reportNewKeys) {
-      if (filePath === 'total') continue
-      temporaryReport[filePath] = coverageReportNew[filePath]
-    }
-    const total: {[index: string]: any} = {
-      lines: {total: 0, covered: 0, skipped: 0, pct: 0},
-      statements: {total: 0, covered: 0, skipped: 0, pct: 0},
-      functions: {total: 0, covered: 0, skipped: 0, pct: 0},
-      branches: {total: 0, covered: 0, skipped: 0, pct: 0}
-    }
-    for (const key in temporaryReport) {
-      if (key === 'total') continue
-      const item = temporaryReport[key]
-      for (const metricType in item) {
-        const metric = item[metricType]
-        total[metricType]['total'] += metric.total
-        total[metricType]['covered'] += metric.covered
-        total[metricType]['skipped'] += metric.skipped
-      }
-    }
-
-    for (const metricType in total) {
-      const metric = total[metricType]
-      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
-    }
-
-    coverageReportNew.total = <FileCoverageData>total
-
-    for (const filePath of reportOldKeys) {
-      // Include file from coverageReportOld in diffCoverageReport
+    for (const filePath of reportKeys) {
       this.diffCoverageReport[filePath] = {
         branches: {
-          newPct: this.getPercentage(coverageReportNew.total?.branches),
-          oldPct: this.getPercentage(coverageReportOld.total?.branches)
+          newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
         },
         statements: {
-          newPct: this.getPercentage(coverageReportNew.total?.statements),
-          oldPct: this.getPercentage(coverageReportOld.total?.statements)
+          newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
         },
         lines: {
-          newPct: this.getPercentage(coverageReportNew.total?.lines),
-          oldPct: this.getPercentage(coverageReportOld.total?.lines)
+          newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
         },
         functions: {
-          newPct: this.getPercentage(coverageReportNew.total?.functions),
-          oldPct: this.getPercentage(coverageReportOld.total?.functions)
+          newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
         }
       }
     }
@@ -105,19 +74,17 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
-    const funcPercentageDiff = this.getPercentageDiff(total.functions)
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      funcPercentageDiff < 0 &&
-      Math.abs(funcPercentageDiff) >= delta
+      -this.getPercentageDiff(total.functions) >= delta
     )
   }
 
   checkIfTestCoverageFallsBelowDelta(delta: number): boolean {
-    const changedFiles = Object.keys(this.diffCoverageReport)
-    for (const fileName of changedFiles) {
-      const diffCoverageData = this.diffCoverageReport[fileName]
+    const keys = Object.keys(this.diffCoverageReport)
+    for (const key of keys) {
+      const diffCoverageData = this.diffCoverageReport[key]
       const keys: ('lines' | 'statements' | 'branches' | 'functions')[] = <
         ('lines' | 'statements' | 'branches' | 'functions')[]
       >Object.keys(diffCoverageData)
@@ -131,8 +98,7 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+          if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -50,12 +50,11 @@ export class DiffChecker {
 
     coverageReportNew.total = <FileCoverageData>total
 
-    console.log('Old Report Total: ', coverageReportOld['total'])
-    console.log('New Report Total: ', coverageReportNew['total'])
-
     for (const filePath of reportKeys) {
       if (reportNewKeys.includes(filePath)) {
-        console.log('Old Report keys: ', coverageReportOld[filePath])
+        console.log(`__________ ${filePath} _________`)
+        console.log(`>> Old Report: <<'`, coverageReportOld[filePath])
+        console.log(`>>> New Report: <<<'`, coverageReportNew[filePath])
         this.diffCoverageReport[filePath] = {
           branches: {
             newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
@@ -75,7 +74,7 @@ export class DiffChecker {
           }
         }
 
-        console.log('---- DIFF : ------', this.diffCoverageReport[filePath])
+        console.log(`-- DIF: --`, this.diffCoverageReport[filePath])
       }
     }
   }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -25,24 +25,22 @@ export class DiffChecker {
     console.log('Report keys: ', reportKeys)
 
     for (const filePath of reportKeys) {
-      if (reportNewKeys.includes(filePath)) {
-        this.diffCoverageReport[filePath] = {
-          branches: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
-          },
-          statements: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
-          },
-          lines: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
-          },
-          functions: {
-            newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
-          }
+      this.diffCoverageReport[filePath] = {
+        branches: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
+        },
+        statements: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
+        },
+        lines: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
+        },
+        functions: {
+          newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
         }
       }
     }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -52,7 +52,7 @@ export class DiffChecker {
 
     for (const filePath of reportKeys) {
       if (reportNewKeys.includes(filePath)) {
-        console.log(`__________ ${filePath} _________`)
+        console.log(`_________ ${filePath} _________`)
         console.log(`>> Old Report: <<'`, coverageReportOld[filePath])
         console.log(`>>> New Report: <<<'`, coverageReportNew[filePath])
         this.diffCoverageReport[filePath] = {
@@ -70,7 +70,9 @@ export class DiffChecker {
           },
           functions: {
             newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
-            oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.functions),
+            newCovered: coverageReportNew[filePath]?.functions.covered,
+            oldCovered: coverageReportOld[filePath]?.functions.covered
           }
         }
 
@@ -112,10 +114,14 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
-    const funcPercentageDiff = this.getPercentageDiff(total.functions)
+    const comparison = {
+      oldPct: total.functions.oldCovered,
+      newPct: total.functions.newCovered
+    }
+    const funcPercentageDiff = this.getPercentageDiff(comparison)
     return (
       total &&
-      total.functions.oldPct !== total.functions.newPct &&
+      total.functions.oldCovered !== total.functions.newCovered &&
       funcPercentageDiff < 0 &&
       Math.abs(funcPercentageDiff) >= delta
     )

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -3,7 +3,6 @@ import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
 import {DiffFileCoverageData} from './Model/DiffFileCoverageData'
 import {DiffCoverageData} from './Model/DiffCoverageData'
-import {FileCoverageData} from './Model/FileCoverageData'
 
 const increasedCoverageIcon = ':green_circle::dog:'
 const decreasedCoverageIcon = ':red_circle:'
@@ -19,35 +18,6 @@ export class DiffChecker {
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
-
-    const temporaryReport = JSON.parse(JSON.stringify(coverageReportOld))
-    for (const filePath of reportNewKeys) {
-      if (filePath === 'total') continue
-      temporaryReport[filePath] = coverageReportNew[filePath]
-    }
-    const total: {[index: string]: any} = {
-      lines: {total: 0, covered: 0, skipped: 0, pct: 0},
-      statements: {total: 0, covered: 0, skipped: 0, pct: 0},
-      functions: {total: 0, covered: 0, skipped: 0, pct: 0},
-      branches: {total: 0, covered: 0, skipped: 0, pct: 0}
-    }
-    for (const key in temporaryReport) {
-      if (key === 'total') continue
-      const item = temporaryReport[key]
-      for (const metricType in item) {
-        const metric = item[metricType]
-        total[metricType]['total'] += metric.total
-        total[metricType]['covered'] += metric.covered
-        total[metricType]['skipped'] += metric.skipped
-      }
-    }
-
-    for (const metricType in total) {
-      const metric = total[metricType]
-      metric.pct = Math.floor((metric.covered / metric.total) * 100 * 100) / 100
-    }
-
-    coverageReportNew.total = <FileCoverageData>total
 
     for (const filePath of reportKeys) {
       this.diffCoverageReport[filePath] = {
@@ -104,19 +74,17 @@ export class DiffChecker {
 
   checkIfTestCoverageFallsBelowTotalFunctionalDelta(delta: number): boolean {
     const {total} = this.diffCoverageReport
-    const funcPercentageDiff = this.getPercentageDiff(total.functions)
     return (
       total &&
       total.functions.oldPct !== total.functions.newPct &&
-      funcPercentageDiff < 0 &&
-      Math.abs(funcPercentageDiff) >= delta
+      -this.getPercentageDiff(total.functions) >= delta
     )
   }
 
   checkIfTestCoverageFallsBelowDelta(delta: number): boolean {
-    const changedFiles = Object.keys(this.diffCoverageReport)
-    for (const fileName of changedFiles) {
-      const diffCoverageData = this.diffCoverageReport[fileName]
+    const keys = Object.keys(this.diffCoverageReport)
+    for (const key of keys) {
+      const diffCoverageData = this.diffCoverageReport[key]
       const keys: ('lines' | 'statements' | 'branches' | 'functions')[] = <
         ('lines' | 'statements' | 'branches' | 'functions')[]
       >Object.keys(diffCoverageData)
@@ -130,8 +98,7 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          const percentageDiff = this.getPercentageDiff(diffCoverageData[key])
-          if (percentageDiff < 0 && Math.abs(percentageDiff) >= delta) {
+          if (-this.getPercentageDiff(diffCoverageData[key]) >= delta) {
             return true
           }
         }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -56,7 +56,6 @@ export class DiffChecker {
     for (const filePath of reportKeys) {
       if (reportNewKeys.includes(filePath)) {
         console.log('Old Report keys: ', coverageReportOld[filePath])
-        console.log('---- DIFF : ------', this.diffCoverageReport[filePath])
         this.diffCoverageReport[filePath] = {
           branches: {
             newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
@@ -75,6 +74,8 @@ export class DiffChecker {
             oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
           }
         }
+
+        console.log('---- DIFF : ------', this.diffCoverageReport[filePath])
       }
     }
   }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -50,18 +50,13 @@ export class DiffChecker {
 
     coverageReportNew.total = <FileCoverageData>total
 
-    console.log('New Report keys: ', coverageReportNew)
-    console.log(
-      'Old Report keys: ',
-      coverageReportOld[
-        '/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts'
-      ]
-    )
-    console.log('Old Report keys: ', coverageReportOld['total'])
-    console.log('Report keys: ', reportKeys)
+    console.log('Old Report Total: ', coverageReportOld['total'])
+    console.log('New Report Total: ', coverageReportNew['total'])
 
     for (const filePath of reportKeys) {
       if (reportNewKeys.includes(filePath)) {
+        console.log('Old Report keys: ', coverageReportOld[filePath])
+        console.log('---- DIFF : ------', this.diffCoverageReport[filePath])
         this.diffCoverageReport[filePath] = {
           branches: {
             newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
@@ -80,11 +75,6 @@ export class DiffChecker {
             oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
           }
         }
-        if (
-          filePath ===
-          '/home/runner/work/frontend/frontend/src/utils/ApiUtils.ts'
-        )
-          console.log('----HEYHEY ------', this.diffCoverageReport[filePath])
       }
     }
   }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -3,6 +3,7 @@ import {DiffCoverageReport} from './Model/DiffCoverageReport'
 import {CoverageData} from './Model/CoverageData'
 import {DiffFileCoverageData} from './Model/DiffFileCoverageData'
 import {DiffCoverageData} from './Model/DiffCoverageData'
+import {FileCoverageData} from './Model/FileCoverageData'
 
 const increasedCoverageIcon = ':green_circle::dog:'
 const decreasedCoverageIcon = ':red_circle:'
@@ -20,22 +21,24 @@ export class DiffChecker {
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     for (const filePath of reportKeys) {
-      this.diffCoverageReport[filePath] = {
-        branches: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
-        },
-        statements: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
-        },
-        lines: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
-        },
-        functions: {
-          newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
-          oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
+      if (reportNewKeys.includes(filePath)) {
+        this.diffCoverageReport[filePath] = {
+          branches: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
+          },
+          statements: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
+          },
+          lines: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
+          },
+          functions: {
+            newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
+            oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
+          }
         }
       }
     }

--- a/src/Model/DiffCoverageData.ts
+++ b/src/Model/DiffCoverageData.ts
@@ -1,4 +1,6 @@
 export interface DiffCoverageData {
   oldPct?: number
   newPct?: number
+  newCovered?: number
+  oldCovered?: number
 }


### PR DESCRIPTION
⚠️ DO NOT REMOVE THIS BRANCH ⚠️

Ticket: https://aquicore.atlassian.net/browse/AQ-15280

> This branch is pretending to replace what s3-coverage-comparison does but with a couple of fixes and improvements.

Frontend repository uses this branch to calculate coverage with remote S3 file as a base.

> name: Test Coverage
> id: testCoverage
> uses: aquicore/Jest-Coverage-Diff@testing-s3-coverage-comparison

⚠️ DO NOT MERGE THIS BRANCH INTO MASTER or s3-coverage-comparison ⚠️

This might break services pipelines (except [frontend](https://github.com/aquicore/frontend)) that rely on aquicore/Jest-Coverage-Diff